### PR TITLE
Make raiden explorer configurable

### DIFF
--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -18,11 +18,16 @@ import { DonutChartComponent } from './components/donut-chart/donut-chart.compon
 import { NetworkGraphComponent } from './components/network-graph/network-graph.component';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatButtonModule, MatProgressSpinnerModule, MatRippleModule, MatTooltipModule } from '@angular/material';
+import { environment } from '../environments/environment';
 
 const appRoutes: Routes = [
   {path: '', redirectTo: '/home', pathMatch: 'full'},
   {path: 'home', component: HomeComponent}
 ];
+
+export function ConfigFactory(config: NetMetricsConfig) {
+  return () => config.load(environment.configurationFile);
+}
 
 @NgModule({
   declarations: [
@@ -58,10 +63,7 @@ const appRoutes: Routes = [
     NetMetricsConfig,
     {
       provide: APP_INITIALIZER,
-      useFactory: f => {
-        return () => {
-        };
-      },
+      useFactory: ConfigFactory,
       deps: [NetMetricsConfig],
       multi: true
     },

--- a/angular-app/src/app/services/net.metrics/net.metrics.config.ts
+++ b/angular-app/src/app/services/net.metrics/net.metrics.config.ts
@@ -1,13 +1,39 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
-import { config } from '../../../assets/config';
+export interface Config {
+  backend_url: string;
+  http_timeout: number;
+  etherscan_base_url: string;
+  network_type: string;
+}
+
+const defaultConfiguration: Config = {
+  backend_url: 'http://explorer.raiden.network:4567/json',
+  http_timeout: 60000,
+  etherscan_base_url: 'https://ropsten.etherscan.io/address/',
+  network_type: 'test'
+};
 
 @Injectable()
 export class NetMetricsConfig {
 
-  public defaultConfig = config;
+  private _configuration: Config = defaultConfiguration;
 
-  constructor() {
+  public get configuration(): Config {
+    return this._configuration;
   }
 
+  constructor(private http: HttpClient) {
+  }
+
+  load(url: string): Promise<any> {
+    return new Promise((resolve) => {
+      this.http.get<Config>(url)
+        .subscribe((config) => {
+          this._configuration = Object.assign({}, defaultConfiguration, config);
+          resolve();
+        });
+    });
+  }
 }

--- a/angular-app/src/app/services/net.metrics/net.metrics.service.ts
+++ b/angular-app/src/app/services/net.metrics/net.metrics.service.ts
@@ -54,7 +54,7 @@ export class NetMetricsService {
    * Get data from server endpoint, then run setCurrentMetrics()
    */
   private getMetrics(): Observable<RaidenNetworkMetrics> {
-    const metrics = this.http.get<NMAPIResponse>(this.nmConfig.defaultConfig.url).pipe(
+    const metrics = this.http.get<NMAPIResponse>(this.nmConfig.configuration.backend_url).pipe(
       map(value => value.result),
       share()
     );

--- a/angular-app/src/assets/config.ts
+++ b/angular-app/src/assets/config.ts
@@ -1,4 +1,0 @@
-export const config = {
-  url: 'http://explorer.raiden.network:4567/json',
-  http_timeout: 600000
-};

--- a/angular-app/src/assets/config/config.development.json
+++ b/angular-app/src/assets/config/config.development.json
@@ -1,0 +1,6 @@
+{
+  "backend_url": "http://explorer.raiden.network:4567/json",
+  "http_timeout": 60000,
+  "etherscan_base_url": "https://ropsten.etherscan.io/address/",
+  "network_type": "test"
+}

--- a/angular-app/src/assets/config/config.production.json
+++ b/angular-app/src/assets/config/config.production.json
@@ -1,0 +1,6 @@
+{
+  "backend_url": "http://explorer.raiden.network:4567/json",
+  "http_timeout": 60000,
+  "etherscan_base_url": "https://etherscan.io/address/",
+  "network_type": "main"
+}

--- a/angular-app/src/environments/environment.prod.ts
+++ b/angular-app/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
   production: true,
+  configurationFile: 'assets/config/config.production.json'
 };

--- a/angular-app/src/environments/environment.ts
+++ b/angular-app/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  configurationFile: 'assets/config/config.development.json'
 };
 
 /*


### PR DESCRIPTION
The configuration file on production will be located at `assets/config/config.production.json`, but if this doesn't fit our needs we can change the location to something else.

Closes #49 